### PR TITLE
Adds Umami analytics to site.

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -11,7 +11,6 @@ export default defineNuxtConfig({
         {
           src: "https://umami.snap.uaf.edu/script.js",
           async: true,
-          defer: true,
           "data-website-id": "57573294-19a7-419c-84d1-b8d3e7c3bc16",
           "data-domains": "aklandslides.org",
           "data-do-not-track": "true",


### PR DESCRIPTION
This PR adds Umami analytics to the site and can be tested by removing the data-domains section of the script declaration and it will allow for http://localhost:3000 to collect analytics.