### PR TITLE
Requested changes to the Risk Level pages

### DIFF
--- a/components/RiskExplaination.vue
+++ b/components/RiskExplaination.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="column is-half">
+    <h3 class="title is-4">Understanding risk</h3>
+
+    <div class="mb-5">
+      <h4 class="title is-5">
+        <span class="tag is-danger is-medium">High</span>
+      </h4>
+      <p>
+        Multiple landslides are very likely to occur in the area. There have
+        been storms with similarly intense rainfall, and all of them initiated
+        multiple landslides.
+      </p>
+    </div>
+
+    <div class="mb-5">
+      <h4 class="title is-5">
+        <span class="tag is-warning is-medium">Medium</span>
+      </h4>
+      <p>
+        Landslides are possible. Isolated landslides have occurred in the area
+        with similarly intense rainfall in the past.
+      </p>
+    </div>
+
+    <div class="mb-5">
+      <h4 class="title is-5">
+        <span class="tag is-success is-medium">Low</span>
+      </h4>
+      <p>
+        Landslides are unlikely based on historic observations. Rainfall-induced
+        landslides have not been documented for these rainfall conditions.
+      </p>
+    </div>
+  </div>
+</template>

--- a/components/RiskLevel.vue
+++ b/components/RiskLevel.vue
@@ -148,10 +148,9 @@ const groupedForecastsByDay = computed<DayGroup[]>(() => {
     if (!existingGroup) {
       let label = "";
       if (isToday(blockDate)) {
-        label = "Today";
+        label = `Today, ${format(blockDate, "MMMM d")}`;
       } else {
-        // Label with name of the day of the week
-        label = format(blockDate, "EEEE");
+        label = `${format(blockDate, "EEEE")}, ${format(blockDate, "MMMM d")}`;
       }
 
       existingGroup = {

--- a/components/RiskLevel.vue
+++ b/components/RiskLevel.vue
@@ -3,7 +3,7 @@
     <div class="box content" style="max-width: 800px">
       <h2 class="title is-4">
         <span
-          class="tag is-medium"
+          class="tag is-large"
           :class="{
             'is-success': landslideApiStore.data.realtime_risk_level === 0,
             'is-warning': landslideApiStore.data.realtime_risk_level === 1,
@@ -20,11 +20,11 @@
       </h2>
       <p>
         <strong>Precipitation:</strong>
-        {{ landslideApiStore.data.realtime_rainfall_mm }} mm
+        {{ mmToInches(landslideApiStore.data.realtime_rainfall_mm) }} in
       </p>
       <p>
         <strong>Previous 24 hours:</strong>
-        {{ landslideApiStore.data.realtime_antecedent_mm }} mm
+        {{ mmToInches(landslideApiStore.data.realtime_antecedent_mm) }} in
       </p>
       <p>
         Last updated at
@@ -67,7 +67,7 @@
                 <tr>
                   <th scope="col">Time</th>
                   <th scope="col">Risk</th>
-                  <th scope="col">Precipitation</th>
+                  <th scope="col">Precipitation - last 3hrs</th>
                   <th scope="col">Past 24 hours</th>
                 </tr>
               </thead>
@@ -86,21 +86,23 @@
                   </td>
                   <td>
                     <span
-                      class="tag"
+                      class="tag is-size-6"
                       :class="{
                         'is-success': block.risk_level === 0,
                         'is-warning': block.risk_level === 1,
                         'is-danger': block.risk_level === 2,
                       }"
                     >
-                      {{ landslideApiStore.getRiskLevelText(block.risk_level) }}
+                      <strong>{{
+                        landslideApiStore.getRiskLevelText(block.risk_level)
+                      }}</strong>
                     </span>
                   </td>
                   <td class="data-cell">
-                    <strong>{{ block.intensity_mm }} mm</strong>
+                    <strong>{{ mmToInches(block.intensity_mm) }} in</strong>
                   </td>
                   <td class="data-cell">
-                    <strong>{{ block.antecedent_mm }} mm</strong>
+                    <strong>{{ mmToInches(block.antecedent_mm) }} in</strong>
                   </td>
                 </tr>
               </tbody>
@@ -176,6 +178,11 @@ const groupedForecastsByDay = computed<DayGroup[]>(() => {
 function formatBlockTime(timestamp: string): string {
   const date = new Date(timestamp);
   return format(date, "h a");
+}
+
+function mmToInches(mm: number): string {
+  const inches = mm * 0.0393701;
+  return inches.toFixed(2);
 }
 </script>
 

--- a/components/RiskLevel.vue
+++ b/components/RiskLevel.vue
@@ -27,12 +27,8 @@
         {{ landslideApiStore.data.realtime_antecedent_mm }} mm
       </p>
       <p>
-        Last updated
-        {{
-          formatDistanceToNow(new Date(landslideApiStore.data.timestamp), {
-            addSuffix: true,
-          })
-        }}
+        Last updated at
+        {{ format(new Date(landslideApiStore.data.timestamp), "h:mm a") }}
       </p>
     </div>
 
@@ -118,7 +114,7 @@
 
 <script setup lang="ts">
 import { useLandslideApiStore } from "~/stores/landslideApi";
-import { formatDistanceToNow, format, isSameDay, isToday } from "date-fns";
+import { format, isSameDay, isToday } from "date-fns";
 import { computed } from "vue";
 import type { ForecastBlock } from "~/types/custom";
 

--- a/pages/[community].vue
+++ b/pages/[community].vue
@@ -18,6 +18,14 @@
         <div v-else class="forecast-loaded">
           <RiskLevel />
         </div>
+        <div class="column is-half">
+          Current precipitation comes from the
+          {{ communityId === "AK91" ? "CRGA2" : "PWKA2" }} rain gauge in
+          {{ communityName }}, which sends its data to
+          <a href="https://synopticdata.com/">Synoptic</a>. Future precipitation
+          and the cumulative precipitation totals come from a weather model
+          called the <a href="https://www.ecmwf.int/">ECMWF</a>.
+        </div>
       </div>
     </ClientOnly>
     <Resources />

--- a/pages/[community].vue
+++ b/pages/[community].vue
@@ -26,6 +26,7 @@
           and the cumulative precipitation totals come from a weather model
           called the <a href="https://www.ecmwf.int/">ECMWF</a>.
         </div>
+        <RiskExplaination />
       </div>
     </ClientOnly>
     <Resources />
@@ -36,6 +37,7 @@
 import { useLandslideApiStore, isCommunityId } from "~/stores/landslideApi";
 import { type CommunityId, CommunityNames, ApiResponse } from "~/types/custom";
 import { ref, watch, computed, onBeforeUnmount } from "vue";
+import RiskExplaination from "~/components/RiskExplaination.vue";
 
 const route = useRoute();
 const landslideApiStore = useLandslideApiStore();


### PR DESCRIPTION
This PR adds the changes that were requested by Luka and his team on the risk level pages. These include the following:

- Risk level text is made more prominent by increasing the size of text and surrounding box.
- Changes all millimeters to inches reflected in the table output
- Rounds the values for all precipitation to 2 decimal places
- Explains the data sources underneath the risk level tables (Synoptic and ECMWF)
- Adds units to the precipitation columns to indicate they are 3 hour values
- Adds the dates to the today, tomorrow, and next day tables
- Adds an "Understanding Risk" section similar to the sitkalandslides.org website
- Changes last updated to the time when it was updated 

Closes #40 
Closes #42 
Closes #43 
Closes #44 
Closes #46 
Closes #47 
Closes #48