### PR TITLE
Values that are below 0.00 inches in precipitation

### DIFF
--- a/components/RiskLevel.vue
+++ b/components/RiskLevel.vue
@@ -181,7 +181,11 @@ function formatBlockTime(timestamp: string): string {
 
 function mmToInches(mm: number): string {
   const inches = mm * 0.0393701;
-  return inches.toFixed(2);
+  const fixedInches = inches.toFixed(2);
+  if (fixedInches === "0.00" && mm > 0) {
+    return "< 0.01";
+  }
+  return fixedInches;
 }
 </script>
 


### PR DESCRIPTION
This PR changes the mmToInches function to check if the value that came in as millimeters was greater than 0 but the amount of rainfall after the conversion and rounding results in inches being 0.00. If that is the case, it now returns < 0.01 and otherwise returns the value in inches.