### PR TITLE
Adds language related to layers not being responsive to current events.

### DIFF
--- a/pages/map.vue
+++ b/pages/map.vue
@@ -1,5 +1,11 @@
 <template>
   <Map />
+  <div class="container">
+    <p>
+      Modeled Landslide Prone Areas not responsive to current or forecasted
+      rainfall
+    </p>
+  </div>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
This PR adds a short text blurb underneath the interactive map to indicate that the map does not represent current or forecasted landslides, but rather only modeled landslide risk.

Closes #49 